### PR TITLE
Remove second function signature.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,12 +5,5 @@
  * @returns New instance of given class constructor with all methods being mocked
  */
 export function createMockInstance<T>(classConstructor: { new(...args: any[]): T } | { (): T }): jest.Mocked<T>;
-/**
- * Create mock instance of given class or function constructor
- * 
- * @param classConstructor Class constructor
- * @returns New instance of given class constructor with all methods being mocked
- */
-export function createMockInstance<T>(classConstructor: Function): jest.Mocked<T>;
 
 export default createMockInstance;


### PR DESCRIPTION
Removing the second function signature fixes #2 for me, and the tests still pass.

Maybe this second signature is needed for something else, but that functionality is not covered by tests.